### PR TITLE
Output fractional seconds in `timestamp.to_rfc3339` function

### DIFF
--- a/test/gleam/time/rfc3339_generator.gleam
+++ b/test/gleam/time/rfc3339_generator.gleam
@@ -2,56 +2,48 @@ import gleam/int
 import gleam/option
 import gleam/regexp
 import gleam/string
+import gleam/time/timestamp
 import qcheck
 
-import gleam/time/timestamp
-
-pub fn timestamp_with_zero_nanoseconds_generator() -> qcheck.Generator(
-  timestamp.Timestamp,
-) {
-  use seconds <- qcheck.map(seconds_for_timestamp_generator())
-
-  timestamp.from_unix_seconds_and_nanoseconds(seconds:, nanoseconds: 0)
-}
-
-// Don't use this one of you also want nanoseconds. Those nanoseconds could push
-// it out of range, and need to be specifically accounted for.
-fn seconds_for_timestamp_generator() {
+/// Generate timestamps representing instants in the range `0000-01-01T00:00:00Z` 
+/// to `9999-12-31T23:59:59.999999999Z`.
+/// 
+pub fn timestamp_generator() {
   // prng can only generate good integers in the range 
   // [-2_147_483_648, 2_147_483_647]
   // 
+  // So we must get to the range we need by generating the values in parts, then
+  // adding them together. 
+  //
   // The smallest number of milliseconds we need to generate:
-  // > d=new Date("0000-01-01T00:00:00+23:59"); d.getTime()
-  // -62_167_305_540_000 ms
-  //     -62_167_305_540 s
+  // > d=new Date("0000-01-01T00:00:00"); d.getTime()
+  // -62_167_201_438_000 ms
+  //     -62_167_201_438 s
   //
   // The largest number of milliseconds without leap second we need to generate:
-  // > d=new Date("9999-12-31T23:59:59-23:59"); d.getTime()
-  // 253_402_387_139_000 ms 
-  //     253_402_387_139 s
+  // > d=new Date("9999-12-31T23:59:59"); d.getTime()
+  // 253_402_318_799_000 ms 
+  //     253_402_318_799 s
   //
-  // (Add in one second to the largest value if you need leap seconds.)
-  //
-  // So we can get to the range we need by generating the values in parts, then
-  // adding them together.  This will also 
 
   let megasecond_generator = {
     use second <- qcheck.map(qcheck.int_uniform_inclusive(-62_167, 253_402))
     second * 1_000_000
   }
 
-  let second_generator = qcheck.int_uniform_inclusive(-305_540, 387_139)
+  let second_generator = qcheck.int_uniform_inclusive(-201_438, 318_799)
 
-  use megasecond, second <- qcheck.map2(
+  use megasecond, second, nanosecond <- qcheck.map3(
     g1: megasecond_generator,
     g2: second_generator,
+    g3: qcheck.int_uniform_inclusive(0, 999_999_999),
   )
   let total_seconds = megasecond + second
 
   let assert True =
-    -62_167_305_540 <= total_seconds && total_seconds <= 253_402_387_140
+    -62_167_201_438 <= total_seconds && total_seconds <= 253_402_318_799
 
-  total_seconds
+  timestamp.from_unix_seconds_and_nanoseconds(total_seconds, nanosecond)
 }
 
 pub fn date_time_generator(

--- a/test/gleam/time/timestamp_test.gleam
+++ b/test/gleam/time/timestamp_test.gleam
@@ -327,10 +327,8 @@ pub fn parse_rfc3339_3_test() {
   |> should.equal(#(60, 550_000_000))
 }
 
-pub fn timestamp_rfc3339_timestamp_roundtrip_property_test() {
-  use timestamp <- qcheck.given(
-    rfc3339_generator.timestamp_with_zero_nanoseconds_generator(),
-  )
+pub fn timestamp_rfc3339_string_timestamp_roundtrip_property_test() {
+  use timestamp <- qcheck.given(rfc3339_generator.timestamp_generator())
 
   let assert Ok(parsed_timestamp) =
     timestamp
@@ -338,18 +336,6 @@ pub fn timestamp_rfc3339_timestamp_roundtrip_property_test() {
     |> timestamp.parse_rfc3339
 
   timestamp.compare(timestamp, parsed_timestamp) == order.Eq
-}
-
-pub fn rfc3339_string_timestamp_rfc3339_string_round_tripping_test() {
-  use timestamp <- qcheck.given(
-    // TODO: switch to generator with nanoseconds once to_rfc3339 handles
-    // fractional seconds.
-    rfc3339_generator.timestamp_with_zero_nanoseconds_generator(),
-  )
-  let assert Ok(parsed_timestamp) =
-    timestamp.to_rfc3339(timestamp, 0) |> timestamp.parse_rfc3339()
-
-  timestamp == parsed_timestamp
 }
 
 // Check against OCaml Ptime reference implementation.

--- a/test/gleam/time/timestamp_test.gleam
+++ b/test/gleam/time/timestamp_test.gleam
@@ -338,6 +338,21 @@ pub fn timestamp_rfc3339_string_timestamp_roundtrip_property_test() {
   timestamp.compare(timestamp, parsed_timestamp) == order.Eq
 }
 
+pub fn rfc3339_string_timestamp_rfc3339_string_roundtrip_property_test() {
+  use date_time <- qcheck.given(rfc3339_generator.date_time_generator(
+    with_leap_second: True,
+    second_fraction_spec: rfc3339_generator.Default,
+    avoid_erlang_errors: False,
+  ))
+
+  let assert Ok(original_timestamp) = timestamp.parse_rfc3339(date_time)
+
+  let assert Ok(roundtrip_timestamp) =
+    original_timestamp |> timestamp.to_rfc3339(0) |> timestamp.parse_rfc3339
+
+  timestamp.compare(original_timestamp, roundtrip_timestamp) == order.Eq
+}
+
 // Check against OCaml Ptime reference implementation.
 //
 // These test cases include leap seconds.

--- a/test/gleam/time/timestamp_test.gleam
+++ b/test/gleam/time/timestamp_test.gleam
@@ -237,6 +237,60 @@ pub fn to_rfc3339_12_test() {
   |> should.equal("0100-01-01T00:00:00Z")
 }
 
+pub fn to_rfc3339_13_test() {
+  timestamp.from_unix_seconds_and_nanoseconds(0, 1)
+  |> timestamp.to_rfc3339(0)
+  |> should.equal("1970-01-01T00:00:00.000000001Z")
+}
+
+pub fn to_rfc3339_14_test() {
+  timestamp.from_unix_seconds_and_nanoseconds(-1, 12)
+  |> timestamp.to_rfc3339(0)
+  |> should.equal("1969-12-31T23:59:59.000000012Z")
+}
+
+pub fn to_rfc3339_15_test() {
+  timestamp.from_unix_seconds_and_nanoseconds(1, 123)
+  |> timestamp.to_rfc3339(0)
+  |> should.equal("1970-01-01T00:00:01.000000123Z")
+}
+
+pub fn to_rfc3339_16_test() {
+  timestamp.from_unix_seconds_and_nanoseconds(0, 1230)
+  |> timestamp.to_rfc3339(0)
+  |> should.equal("1970-01-01T00:00:00.00000123Z")
+}
+
+pub fn to_rfc3339_17_test() {
+  timestamp.from_unix_seconds_and_nanoseconds(0, 500_600_000)
+  |> timestamp.to_rfc3339(0)
+  |> should.equal("1970-01-01T00:00:00.5006Z")
+}
+
+pub fn to_rfc3339_18_test() {
+  timestamp.from_unix_seconds_and_nanoseconds(0, 500_006)
+  |> timestamp.to_rfc3339(0)
+  |> should.equal("1970-01-01T00:00:00.000500006Z")
+}
+
+pub fn to_rfc3339_19_test() {
+  timestamp.from_unix_seconds_and_nanoseconds(0, 999_999_999)
+  |> timestamp.to_rfc3339(0)
+  |> should.equal("1970-01-01T00:00:00.999999999Z")
+}
+
+pub fn to_rfc3339_20_test() {
+  timestamp.from_unix_seconds_and_nanoseconds(0, 0)
+  |> timestamp.to_rfc3339(0)
+  |> should.equal("1970-01-01T00:00:00Z")
+}
+
+pub fn to_rfc3339_21_test() {
+  timestamp.from_unix_seconds_and_nanoseconds(0, 1_000_000_001)
+  |> timestamp.to_rfc3339(0)
+  |> should.equal("1970-01-01T00:00:01.000000001Z")
+}
+
 // RFC 3339 Parsing
 
 pub fn parse_rfc3339_0_test() {


### PR DESCRIPTION
Output fractional seconds in `timestamp.to_rfc3339` function.

I figured it may be best to avoid a method that divides the nanoseconds by 1 billion, then converts that float to a string using `float.to_string`, so that we can fully control the format.  (E.g., it won't depend on any changes to how stdlib prints float strings or anything else like that.) And so, it uses that "digit arithmetic" method that you see.

Additionally, I [mentioned](https://github.com/gleam-lang/time/pull/12) needing to update some of the round-trip tests once the fractional seconds are printed by `timestamp.to_rfc3339`.  This PR includes those test updates as well.