### PR TITLE
Fixes for time zone conversions

### DIFF
--- a/src/gleam/time/timestamp.gleam
+++ b/src/gleam/time/timestamp.gleam
@@ -300,7 +300,7 @@ fn to_calendar_from_offset(
   timestamp: Timestamp,
   offset: Int,
 ) -> #(Int, Int, Int, Int, Int, Int) {
-  let total = timestamp.seconds - { offset * 60 }
+  let total = timestamp.seconds + { offset * 60 }
   let seconds = modulo(total, 60)
   let total_minutes = floored_div(total, 60.0)
   let minutes = modulo(total, 60 * 60) / 60

--- a/src/gleam_time_ffi.mjs
+++ b/src/gleam_time_ffi.mjs
@@ -7,5 +7,5 @@ export function system_time() {
 }
 
 export function local_time_offset_seconds() {
-  return new Date().getTimezoneOffset() * 60;
+  return new Date().getTimezoneOffset() * -60;
 }

--- a/test/gleam/time/timestamp_test.gleam
+++ b/test/gleam/time/timestamp_test.gleam
@@ -203,15 +203,15 @@ pub fn to_rfc3339_6_test() {
 }
 
 pub fn to_rfc3339_7_test() {
-  timestamp.from_unix_seconds(60 * 60 + 60 * 5)
+  timestamp.from_unix_seconds(-60 * 60 - 60 * 5)
   |> timestamp.to_rfc3339(duration.seconds(65 * 60))
   |> should.equal("1970-01-01T00:00:00+01:05")
 }
 
 pub fn to_rfc3339_8_test() {
   timestamp.from_unix_seconds(0)
-  |> timestamp.to_rfc3339(duration.seconds(-120 * 60))
-  |> should.equal("1970-01-01T02:00:00-02:00")
+  |> timestamp.to_rfc3339(duration.seconds(120 * 60))
+  |> should.equal("1970-01-01T02:00:00+02:00")
 }
 
 pub fn to_rfc3339_9_test() {

--- a/test/gleam/time/timestamp_test.gleam
+++ b/test/gleam/time/timestamp_test.gleam
@@ -356,6 +356,25 @@ pub fn rfc3339_string_timestamp_rfc3339_string_roundtrip_property_test() {
   original_timestamp == roundtrip_timestamp
 }
 
+// Eastern US Timezone round trip tests
+pub fn rfc3339_string_timestamp_rfc3339_string_roundtrip_to_est_test() {
+  let assert Ok(date_time) =
+    timestamp.parse_rfc3339("2025-02-04T13:00:00+00:00")
+
+  date_time
+  |> timestamp.to_rfc3339(duration.seconds(-18_000))
+  |> should.equal("2025-02-04T08:00:00-05:00")
+}
+
+pub fn rfc3339_string_timestamp_rfc3339_string_roundtrip_from_est_test() {
+  let assert Ok(date_time) =
+    timestamp.parse_rfc3339("2025-02-04T13:00:00-05:00")
+
+  date_time
+  |> timestamp.to_rfc3339(calendar.utc_offset)
+  |> should.equal("2025-02-04T18:00:00Z")
+}
+
 // Check against OCaml Ptime reference implementation.
 //
 // These test cases include leap seconds.


### PR DESCRIPTION
This addresses issue #15 where there was both a discrepancy between the erlang and javascript targets when converting timestamps into different time zones. This also adds two tests which load RFC3339 dates in one time zone and write them out to a different time zone. 