### PR TITLE
Improve timestamp to_rfc3339 docs

### DIFF
--- a/src/gleam/time/timestamp.gleam
+++ b/src/gleam/time/timestamp.gleam
@@ -220,8 +220,15 @@ pub fn add(timestamp: Timestamp, duration: Duration) -> Timestamp {
 /// # Examples
 ///
 /// ```gleam
-/// to_rfc3339(from_unix_seconds(1000), 0)
-/// // -> "1970-01-01T00:00:00Z"
+/// timestamp.from_unix_seconds_and_nanoseconds(1000, 123_000_000)
+/// |> to_rfc3339(calendar.utc_offset)
+/// // -> "1970-01-01T00:16:40.123Z"
+/// ```
+///
+/// ```gleam
+/// timestamp.from_unix_seconds(1000)
+/// |> to_rfc3339(duration.seconds(3600))
+/// // -> "1970-01-01T01:16:40+01:00"
 /// ```
 ///
 pub fn to_rfc3339(timestamp: Timestamp, offset: Duration) -> String {


### PR DESCRIPTION
Fixes an outdated example of providing a 0 offset to the `to_rfc3339` function and adds another example showing that the output string length depends on the precision of the timestamp. Reading the docs my initial impression what that this string was only ever formatted with second precision. I think adding the second example provides clarity into the function's behavior with different inputs.