### PR TITLE
Add day, week, month, and year functions

### DIFF
--- a/src/gleam/time/duration.gleam
+++ b/src/gleam/time/duration.gleam
@@ -260,15 +260,19 @@ pub fn weeks(amount: Int) -> Duration {
 }
 
 /// Create a duration of a number of months.
+/// This is calculated based on the approximated 30.4375 days given in the Units
+/// type definition, rounded to the nearest second.
 pub fn months(amount: Int) -> Duration {
-  int.to_float(amount) *. 60.0 *. 60.0 *. 24.0 *. 7.0 *. 30.437
+  int.to_float(amount) *. 60.0 *. 60.0 *. 24.0 *. 30.4375
   |> float.round()
   |> seconds()
 }
 
 /// Create a duration of a number of years.
+/// This is calculated based on the approximated 365.25 days given in the Units
+/// type definition, rounded to the nearest second.
 pub fn years(amount: Int) -> Duration {
-  int.to_float(amount) *. 60.0 *. 60.0 *. 24.0 *. 7.0 *. 30.437 *. 365.25
+  int.to_float(amount) *. 60.0 *. 60.0 *. 24.0 *. 365.25
   |> float.round()
   |> seconds()
 }

--- a/src/gleam/time/duration.gleam
+++ b/src/gleam/time/duration.gleam
@@ -259,6 +259,20 @@ pub fn weeks(amount: Int) -> Duration {
   seconds(amount * 60 * 60 * 24 * 7)
 }
 
+/// Create a duration of a number of months.
+pub fn months(amount: Int) -> Duration {
+  int.to_float(amount) *. 60.0 *. 60.0 *. 24.0 *. 7.0 *. 30.437
+  |> float.round()
+  |> seconds()
+}
+
+/// Create a duration of a number of years.
+pub fn years(amount: Int) -> Duration {
+  int.to_float(amount) *. 60.0 *. 60.0 *. 24.0 *. 7.0 *. 30.437 *. 365.25
+  |> float.round()
+  |> seconds()
+}
+
 /// Create a duration of a number of milliseconds.
 pub fn milliseconds(amount: Int) -> Duration {
   let remainder = amount % 1000

--- a/src/gleam/time/duration.gleam
+++ b/src/gleam/time/duration.gleam
@@ -1,6 +1,7 @@
 import gleam/int
 import gleam/order
 import gleam/string
+import gleam/float
 
 /// An amount of time, with up to nanosecond precision.
 ///
@@ -246,6 +247,16 @@ pub fn minutes(amount: Int) -> Duration {
 /// Create a duration of a number of hours.
 pub fn hours(amount: Int) -> Duration {
   seconds(amount * 60 * 60)
+}
+
+/// Create a duration of a number of days.
+pub fn days(amount: Int) -> Duration {
+  seconds(amount * 60 * 60 * 24)
+}
+
+/// Create a duration of a number of weeks.
+pub fn weeks(amount: Int) -> Duration {
+  seconds(amount * 60 * 60 * 24 * 7)
 }
 
 /// Create a duration of a number of milliseconds.


### PR DESCRIPTION
Days and weeks follow the format for the existing minutes and hours durations. Months and years are calculated based on the values given in the Units type definition then rounded to the nearest second