### PR TITLE
Use OTP 28 in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,15 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        otp-version: ["27", "28"]
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "27"
-          gleam-version: "1.11.1"
+          otp-version: ${{ matrix.otp-version }}
+          gleam-version: "1.13.0"
           rebar3-version: "3"
       - run: gleam deps download
       - run: gleam test --target erlang

--- a/test/gleam_time_test_ffi.erl
+++ b/test/gleam_time_test_ffi.erl
@@ -13,6 +13,7 @@ rfc3339_to_system_time_in_milliseconds(Timestamp) when is_binary(Timestamp) ->
             {error, nil}
     end.
 
+-if(?OTP_RELEASE < 28).
 % TODO: this time adjustment will need to be removed once the bug is fixed
 % upstream: https://github.com/erlang/otp/issues/9279.
 adjust_system_time(Milliseconds) when is_integer(Milliseconds) ->
@@ -24,3 +25,7 @@ adjust_system_time(Milliseconds) when is_integer(Milliseconds) ->
             Fractional_seconds = Milliseconds rem 1_000,
             Milliseconds - 2 * Fractional_seconds
     end.
+-else.
+% On OTP 28 the bug has been fixed, so there's no adjusting to be done.
+adjust_system_time(Milliseconds) -> Milliseconds.
+-endif.


### PR DESCRIPTION
This PR updates the OTP version used in CI and the FFI test code to remove a workaround meant for OTP 27