### PR TITLE
Add `naive_date_compare`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- The `calendar` module gains the `naive_date_compare` function.
+
 ## v1.4.0 - 2025-07-15
 
 - RFC3339 timestamps with a space between the date and the time can now be

--- a/src/gleam/time/calendar.gleam
+++ b/src/gleam/time/calendar.gleam
@@ -87,6 +87,8 @@
 //// If you are making an API such as a HTTP JSON API you are encouraged to use
 //// Unix timestamps instead of calendar times.
 
+import gleam/int
+import gleam/order.{type Order}
 import gleam/time/duration
 
 /// The Gregorian calendar date. Ambiguous without a time zone.
@@ -319,4 +321,14 @@ pub fn is_valid_time_of_day(time: TimeOfDay) -> Bool {
   && seconds <= 59
   && nanoseconds >= 0
   && nanoseconds <= 999_999_999
+}
+
+/// Compares two dates, returning an order.
+///
+pub fn naive_date_compare(one: Date, other: Date) -> Order {
+  int.compare(one.year, other.year)
+  |> order.lazy_break_tie(fn() {
+    int.compare(month_to_int(one.month), month_to_int(other.month))
+  })
+  |> order.lazy_break_tie(fn() { int.compare(one.day, other.day) })
 }

--- a/test/gleam/time/calendar_test.gleam
+++ b/test/gleam/time/calendar_test.gleam
@@ -1,4 +1,5 @@
 import gleam/float
+import gleam/order
 import gleam/time/calendar
 import gleam/time/duration
 import gleeunit/should
@@ -186,4 +187,60 @@ pub fn is_valid_time_of_day_edge_cases_test() {
 
   // Minimum valid values
   assert calendar.is_valid_time_of_day(calendar.TimeOfDay(0, 0, 0, 0))
+}
+
+pub fn compare_date_with_smaller_year_test() {
+  assert order.Lt
+    == calendar.naive_date_compare(
+      calendar.Date(1998, calendar.October, 11),
+      calendar.Date(1999, calendar.October, 11),
+    )
+}
+
+pub fn compares_date_with_smaller_month_test() {
+  assert order.Lt
+    == calendar.naive_date_compare(
+      calendar.Date(1998, calendar.October, 11),
+      calendar.Date(1998, calendar.November, 11),
+    )
+}
+
+pub fn compare_date_with_smaller_day_test() {
+  assert order.Lt
+    == calendar.naive_date_compare(
+      calendar.Date(1998, calendar.October, 11),
+      calendar.Date(1998, calendar.October, 12),
+    )
+}
+
+pub fn compare_equal_dates_test() {
+  assert order.Eq
+    == calendar.naive_date_compare(
+      calendar.Date(1998, calendar.October, 11),
+      calendar.Date(1998, calendar.October, 11),
+    )
+}
+
+pub fn compare_date_with_bigger_year_test() {
+  assert order.Gt
+    == calendar.naive_date_compare(
+      calendar.Date(1999, calendar.October, 11),
+      calendar.Date(1998, calendar.October, 11),
+    )
+}
+
+pub fn compare_date_with_bigger_month_test() {
+  assert order.Gt
+    == calendar.naive_date_compare(
+      calendar.Date(1998, calendar.November, 11),
+      calendar.Date(1998, calendar.October, 11),
+    )
+}
+
+pub fn compare_date_with_bigger_day_test() {
+  assert order.Gt
+    == calendar.naive_date_compare(
+      calendar.Date(1998, calendar.October, 12),
+      calendar.Date(1998, calendar.October, 11),
+    )
 }


### PR DESCRIPTION
This PR closes #28 
I think this could use more documentation explaining why the "naive" and why one might not want to use it. Though I know nearly enough to write something useful here I'm afraid