### PR TITLE
return valid iso8601 representation of zero seconds duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed a bug where the `duration.to_iso8601_string` returned an invalid value
+  for a duration of `0` seconds.
 - The `timestamp` module gains the `unix_epoch` constant.
 
 ## v1.5.0 - 2025-11-01

--- a/src/gleam/time/duration.gleam
+++ b/src/gleam/time/duration.gleam
@@ -210,10 +210,11 @@ pub fn to_iso8601_string(duration: Duration) -> String {
     |> string.append("T")
     |> add(hours, "H")
     |> add(minutes, "M")
-  case seconds, duration.nanoseconds {
-    0, 0 -> output
-    _, 0 -> output <> int.to_string(seconds) <> "S"
-    _, _ -> {
+  case output, seconds, duration.nanoseconds {
+    "PT", 0, 0 -> output <> "0S"
+    _, 0, 0 -> output
+    _, _, 0 -> output <> int.to_string(seconds) <> "S"
+    _, _, _ -> {
       let f = nanosecond_digits(duration.nanoseconds, 0, "")
       output <> int.to_string(seconds) <> "." <> f <> "S"
     }

--- a/test/gleam/time/duration_test.gleam
+++ b/test/gleam/time/duration_test.gleam
@@ -223,6 +223,36 @@ pub fn compare_7_test() {
   |> should.equal(order.Eq)
 }
 
+pub fn to_iso8601_string_0_nanoseconds_test() {
+  duration.nanoseconds(0)
+  |> duration.to_iso8601_string
+  |> should.equal("PT0S")
+}
+
+pub fn to_iso8601_string_0_milliseconds_test() {
+  duration.milliseconds(0)
+  |> duration.to_iso8601_string
+  |> should.equal("PT0S")
+}
+
+pub fn to_iso8601_string_0_seconds_test() {
+  duration.seconds(0)
+  |> duration.to_iso8601_string
+  |> should.equal("PT0S")
+}
+
+pub fn to_iso8601_string_0_minutes_test() {
+  duration.minutes(0)
+  |> duration.to_iso8601_string
+  |> should.equal("PT0S")
+}
+
+pub fn to_iso8601_string_0_hours_test() {
+  duration.hours(0)
+  |> duration.to_iso8601_string
+  |> should.equal("PT0S")
+}
+
 pub fn to_iso8601_string_0_test() {
   duration.seconds(42)
   |> duration.to_iso8601_string


### PR DESCRIPTION
This PR fixes an issue with `duration.to_iso8601_seconds` where passing in a duration of zero seconds does not return a valid iso8601 string representation.

[ISO_8601](https://en.wikipedia.org/wiki/ISO_8601#Durations)

> Date and time elements including their designator may be omitted if their value is zero, and lower-order elements may also be omitted for reduced precision. For example, "P23DT23H" and "P4Y" are both acceptable duration representations. However, at least one element must be present, thus "P" is not a valid representation for a duration of 0 seconds. "PT0S" or "P0D", however, are both valid and represent the same duration. 

Current behaviour:

```gleam
duration.seconds(0)
|> duration.to_iso8601_string
// "PT"
```

New behaviour:

```gleam
duration.seconds(0)
|> duration.to_iso8601_string
// "PT0S"
```

This matches the behaviour provided by the [timex](https://github.com/bitwalker/timex/blob/5ad1b8206977ebffb3bf72f88c18d490c36151c8/lib/format/duration/formatters/default.ex#L58-L60) elixir package.