### PR TITLE
Add documentation for adding negative duration on timestamp.add()

### DIFF
--- a/src/gleam/time/timestamp.gleam
+++ b/src/gleam/time/timestamp.gleam
@@ -185,11 +185,18 @@ pub fn difference(left: Timestamp, right: Timestamp) -> Duration {
 
 /// Add a duration to a timestamp.
 ///
+/// You can add a negative duration to substract from a timestamp.
+///
 /// # Examples
 ///
 /// ```gleam
 /// add(from_unix_seconds(1000), duration.seconds(5))
 /// // -> from_unix_seconds(1005)
+/// ```
+///
+/// ```gleam
+/// add(from_unix_seconds(1000), duration.seconds(-5))
+/// // -> from_unix_seconds(995)
 /// ```
 ///
 pub fn add(timestamp: Timestamp, duration: Duration) -> Timestamp {


### PR DESCRIPTION
Adds documentation for the possibility to add a negative duration to a timestamp in order to subtract from a timestamp.

In hindsight this seems obvious, but I was half way through implementing my own `substract(Timestamp, Duration)` before realizing that negative durations are a thing and that adding a negative duration can be used to subtract from a Timestamp.