### PR TITLE
feat: add monotonic time module

### DIFF
--- a/src/gleam/time/monotonic.gleam
+++ b/src/gleam/time/monotonic.gleam
@@ -1,0 +1,77 @@
+//// Monotonic time for measuring local elapsed time.
+////
+//// Monotonic instants are useful when you need to measure elapsed time between
+//// events and wall-clock changes must not affect the result. For example, use
+//// this module for timeouts, peer liveness checks, or benchmarking.
+////
+//// An `Instant` is not a timestamp. It does not represent calendar time, Unix
+//// time, or any globally meaningful point in time. Do not store it, display it
+//// to users, send it to other machines, or compare values created by different
+//// runtime instances.
+////
+//// On Erlang this uses [`erlang:monotonic_time/1`][erlang]. On JavaScript this
+//// uses [`performance.now`][javascript].
+////
+//// [erlang]: https://www.erlang.org/doc/apps/erts/erlang.html#monotonic_time/1
+//// [javascript]: https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
+
+import gleam/int
+import gleam/order
+import gleam/time/duration.{type Duration}
+
+/// A monotonic instant from the local runtime.
+///
+/// Instants are only meaningful when compared with other instants created by
+/// this module in the same runtime instance.
+pub opaque type Instant {
+  Instant(seconds: Int, nanoseconds: Int)
+}
+
+/// Get the current monotonic instant.
+///
+/// The returned value is not wall-clock time. It should only be used for
+/// measuring elapsed local time.
+pub fn now() -> Instant {
+  let #(seconds, nanoseconds) = monotonic_time()
+  Instant(seconds, nanoseconds)
+  |> normalise
+}
+
+@external(erlang, "gleam_time_ffi", "monotonic_time")
+@external(javascript, "../../gleam_time_ffi.mjs", "monotonic_time")
+fn monotonic_time() -> #(Int, Int)
+
+/// Compare two monotonic instants.
+pub fn compare(left: Instant, right: Instant) -> order.Order {
+  order.break_tie(
+    int.compare(left.seconds, right.seconds),
+    int.compare(left.nanoseconds, right.nanoseconds),
+  )
+}
+
+/// Calculate the elapsed duration between two monotonic instants.
+///
+/// This is effectively subtracting the first instant from the second. If the
+/// second instant is earlier than the first, the returned duration will be
+/// negative.
+pub fn difference(left: Instant, right: Instant) -> Duration {
+  let seconds = duration.seconds(right.seconds - left.seconds)
+  let nanoseconds = duration.nanoseconds(right.nanoseconds - left.nanoseconds)
+  duration.add(seconds, nanoseconds)
+}
+
+/// Calculate the duration elapsed since a monotonic instant.
+pub fn elapsed_since(instant: Instant) -> Duration {
+  difference(instant, now())
+}
+
+fn normalise(instant: Instant) -> Instant {
+  let multiplier = 1_000_000_000
+  let nanoseconds = instant.nanoseconds % multiplier
+  let overflow = instant.nanoseconds - nanoseconds
+  let seconds = instant.seconds + overflow / multiplier
+  case nanoseconds >= 0 {
+    True -> Instant(seconds, nanoseconds)
+    False -> Instant(seconds - 1, multiplier + nanoseconds)
+  }
+}

--- a/src/gleam_time_ffi.erl
+++ b/src/gleam_time_ffi.erl
@@ -1,8 +1,11 @@
 -module(gleam_time_ffi).
--export([system_time/0, local_time_offset_seconds/0]).
+-export([system_time/0, monotonic_time/0, local_time_offset_seconds/0]).
 
 system_time() ->
     {0, erlang:system_time(nanosecond)}.
+
+monotonic_time() ->
+    {0, erlang:monotonic_time(nanosecond)}.
 
 local_time_offset_seconds() ->
     Utc = calendar:universal_time(),

--- a/src/gleam_time_ffi.mjs
+++ b/src/gleam_time_ffi.mjs
@@ -6,6 +6,13 @@ export function system_time() {
   return [seconds, nanoseconds];
 }
 
+export function monotonic_time() {
+  const milliseconds = globalThis.performance.now();
+  const seconds = Math.floor(milliseconds / 1_000);
+  const nanoseconds = Math.floor((milliseconds - seconds * 1_000) * 1_000_000);
+  return [seconds, nanoseconds];
+}
+
 export function local_time_offset_seconds() {
   return new Date().getTimezoneOffset() * -60;
 }

--- a/test/gleam/time/monotonic_test.gleam
+++ b/test/gleam/time/monotonic_test.gleam
@@ -3,8 +3,8 @@ import gleam/time/duration
 import gleam/time/monotonic
 
 fn is_not_negative(d: duration.Duration) -> Bool {
-  let #(seconds, _nanoseconds) = duration.to_seconds_and_nanoseconds(d)
-  seconds >= 0
+  let #(seconds, nanoseconds) = duration.to_seconds_and_nanoseconds(d)
+  seconds > 0 || { seconds == 0 && nanoseconds >= 0 }
 }
 
 pub fn now_can_be_compared_test() {

--- a/test/gleam/time/monotonic_test.gleam
+++ b/test/gleam/time/monotonic_test.gleam
@@ -1,0 +1,42 @@
+import gleam/order
+import gleam/time/duration
+import gleam/time/monotonic
+
+pub fn now_can_be_compared_test() {
+  let start = monotonic.now()
+  let finish = monotonic.now()
+
+  let is_ordered = case monotonic.compare(start, finish) {
+    order.Lt | order.Eq -> True
+    order.Gt -> False
+  }
+
+  assert is_ordered
+}
+
+pub fn difference_between_ordered_instants_is_not_negative_test() {
+  let start = monotonic.now()
+  let finish = monotonic.now()
+
+  let is_not_negative = case monotonic.difference(start, finish)
+    |> duration.compare(duration.nanoseconds(0))
+  {
+    order.Lt -> False
+    order.Eq | order.Gt -> True
+  }
+
+  assert is_not_negative
+}
+
+pub fn elapsed_since_is_not_negative_test() {
+  let start = monotonic.now()
+
+  let is_not_negative = case monotonic.elapsed_since(start)
+    |> duration.compare(duration.nanoseconds(0))
+  {
+    order.Lt -> False
+    order.Eq | order.Gt -> True
+  }
+
+  assert is_not_negative
+}

--- a/test/gleam/time/monotonic_test.gleam
+++ b/test/gleam/time/monotonic_test.gleam
@@ -3,8 +3,9 @@ import gleam/time/duration
 import gleam/time/monotonic
 
 fn is_not_negative(d: duration.Duration) -> Bool {
-  let #(seconds, nanoseconds) = duration.to_seconds_and_nanoseconds(d)
-  seconds > 0 || { seconds == 0 && nanoseconds >= 0 }
+  let #(seconds, _nanoseconds) = duration.to_seconds_and_nanoseconds(d)
+  // Durations are normalised, so the seconds field carries the sign.
+  seconds >= 0
 }
 
 pub fn now_can_be_compared_test() {

--- a/test/gleam/time/monotonic_test.gleam
+++ b/test/gleam/time/monotonic_test.gleam
@@ -18,7 +18,8 @@ pub fn difference_between_ordered_instants_is_not_negative_test() {
   let start = monotonic.now()
   let finish = monotonic.now()
 
-  let is_not_negative = case monotonic.difference(start, finish)
+  let is_not_negative = case
+    monotonic.difference(start, finish)
     |> duration.compare(duration.nanoseconds(0))
   {
     order.Lt -> False
@@ -31,7 +32,8 @@ pub fn difference_between_ordered_instants_is_not_negative_test() {
 pub fn elapsed_since_is_not_negative_test() {
   let start = monotonic.now()
 
-  let is_not_negative = case monotonic.elapsed_since(start)
+  let is_not_negative = case
+    monotonic.elapsed_since(start)
     |> duration.compare(duration.nanoseconds(0))
   {
     order.Lt -> False

--- a/test/gleam/time/monotonic_test.gleam
+++ b/test/gleam/time/monotonic_test.gleam
@@ -2,6 +2,11 @@ import gleam/order
 import gleam/time/duration
 import gleam/time/monotonic
 
+fn is_not_negative(d: duration.Duration) -> Bool {
+  let #(seconds, _nanoseconds) = duration.to_seconds_and_nanoseconds(d)
+  seconds >= 0
+}
+
 pub fn now_can_be_compared_test() {
   let start = monotonic.now()
   let finish = monotonic.now()
@@ -18,27 +23,11 @@ pub fn difference_between_ordered_instants_is_not_negative_test() {
   let start = monotonic.now()
   let finish = monotonic.now()
 
-  let is_not_negative = case
-    monotonic.difference(start, finish)
-    |> duration.compare(duration.nanoseconds(0))
-  {
-    order.Lt -> False
-    order.Eq | order.Gt -> True
-  }
-
-  assert is_not_negative
+  assert is_not_negative(monotonic.difference(start, finish))
 }
 
 pub fn elapsed_since_is_not_negative_test() {
   let start = monotonic.now()
 
-  let is_not_negative = case
-    monotonic.elapsed_since(start)
-    |> duration.compare(duration.nanoseconds(0))
-  {
-    order.Lt -> False
-    order.Eq | order.Gt -> True
-  }
-
-  assert is_not_negative
+  assert is_not_negative(monotonic.elapsed_since(start))
 }


### PR DESCRIPTION
Closes #46.

## Summary

Adds a new `gleam/time/monotonic` module for measuring local elapsed time using a clock that is not affected by wall-clock changes (NTP adjustments, manual clock changes, leap-second smearing, VM suspend/resume).

- New opaque `Instant` type, deliberately separate from `timestamp.Timestamp` to avoid the wall-clock footguns discussed in #3 and #6.
- `now`, `compare`, `difference`, and `elapsed_since` functions; `difference` returns a signed `Duration` from the existing `gleam/time/duration` module.
- Erlang FFI backed by `erlang:monotonic_time(nanosecond)`; JavaScript FFI backed by `performance.now()`. Both return `(seconds, nanoseconds)` tuples that are normalised on the Gleam side.
- Module-level docs call out that instants are not timestamps and are only meaningful within the same runtime instance (do not store, display, or send across machines).

## Motivation

The triggering use case is peer-liveness expiry in a Gleam/Erlang LAN application: nodes record "last seen at" for each peer and expire them after a threshold. Using `timestamp.system_time()` for this is unsafe — wall-clock time may jump backwards (NTP step, manual clock change, leap-second smearing, VM clock drift after suspend/resume), making peers either expire prematurely or appear to live forever.

The same problem applies to:

- **Timeouts / deadlines** — `deadline = now + 30s` is wrong if `now` jumps.
- **Benchmarks / latency measurement** — wall-clock noise contaminates microbenchmarks.
- **Rate limiting / debouncing** — interval-based logic relies on monotonicity.
- **Retry/backoff schedulers** — re-fires can collapse or stall if time jumps.

Issues #3 and #6 covered the wall-clock semantics of `timestamp` and explicitly chose to keep that module simple. This PR adds the missing capability as a separate module rather than complicating `timestamp`.

## Prior art surveyed

| Language | API | Notes |
|---|---|---|
| **Rust** `std::time::Instant` | Opaque type; `Instant::now()`, `duration_since`, `elapsed`, `+`/`-` `Duration` | Explicitly documents instants as "opaque and useful only with `Duration`". Strong philosophical match. |
| **Go** `time.Time` | Hybrid: monotonic reading embedded inside the wall-clock `Time`. Subtraction uses the monotonic component when available; serialization strips it. | Clever but subtle — easy to lose monotonicity by round-tripping through JSON. Rejected as a model because it requires teaching users which operations preserve monotonicity. |
| **Java** `System.nanoTime()` | Bare `long`. Documented "only useful for measuring elapsed time". | Footgun: an `Int` looks like something you can store or send. |
| **Python** `time.monotonic()` / `time.monotonic_ns()` | Returns `float` / `int` from an unspecified reference point. | Same footgun as Java. |
| **Erlang** `erlang:monotonic_time/Unit` | Integer in chosen unit, opaque reference, strictly monotonic by default (configurable via time-warp mode). | The underlying primitive used here. |
| **JavaScript** `performance.now()` | `DOMHighResTimeStamp` (float ms) since a time origin. Monotonically non-decreasing per context. Browser resolution clamped for Spectre mitigation. | The underlying primitive used here. |
| **Elm** `elm/time` | No monotonic equivalent. | Not applicable. |

The Rust model is the closest fit for Gleam: opaque, can't be confused with wall-clock, integrates with `Duration`, no serialization story to get wrong.

## Design considerations

1. **Separate module vs. extending `timestamp`.** Go's approach (one type, both clocks) gives ergonomics but creates correctness traps the maintainers have already chosen to avoid. A dedicated `gleam/time/monotonic` module keeps `Timestamp` pure and gives `Instant` its own type so the compiler enforces "don't mix these".

2. **Opaque `Instant` type.** Making the constructor private prevents users from materialising instants from `Int` values, storing them, sending them over the wire, or comparing instants from different runtime instances and getting a meaningful answer. The `(seconds, nanoseconds)` internal shape mirrors `Timestamp` only as an implementation convenience.

3. **Integration with `Duration`.** `difference` returns the existing `Duration` type rather than a bare `Int` of nanoseconds. Users get the full `Duration` API (formatting, comparison, arithmetic) for free, and it discourages the "store ms as Int" pattern the original issue sketched.

4. **Surface area kept small.** Just `now`, `compare`, `difference`, `elapsed_since`. No serialisation, no `from_*` constructors, no `to_int_ms`. Add more only when a concrete need shows up.

5. **FFI shape matches `system_time`.** Both FFIs return `#(seconds, nanoseconds)` and normalise on the Gleam side. Erlang uses `erlang:monotonic_time(nanosecond)` (full ns resolution); JavaScript uses `performance.now()` (ms with sub-ms in Node, often coarsened in browsers).

6. **No runtime-identity tagging.** Considered tagging each `Instant` with a session id to detect "comparing instants from different runs" at runtime. Rejected as overkill — the type-level "don't store, don't send" guidance plus the opaque type seems enough, and tagging would cost an extra field plus runtime checks.

## Pros

- Type-level safety: `Instant` and `Timestamp` cannot be mixed up.
- Opaque construction blocks the worst misuses (store / display / send).
- Reuses `Duration` so the API composes with existing code.
- Tiny surface — easy to learn, easy to evolve.
- Cross-target with a clear, documented mapping to each runtime's primitive.

## Cons / open questions

1. **Resolution varies by target.** Browser `performance.now()` is intentionally coarsened (~100µs–1ms) for Spectre mitigation; Node gives much higher resolution; Erlang gives full ns. Users measuring sub-ms intervals on the web will see quantisation. Could be called out more loudly in the docs.

2. **Erlang time-warp mode.** `erlang:monotonic_time/1` is strictly monotonic by default but configurable. Worth a doc note that callers in unusual VM configurations may want to verify.

3. **`compare` vs `difference` overlap.** `compare(a, b)` is equivalent to `duration.compare(difference(a, b), duration.nanoseconds(0))`. Keeping both is mild API duplication; dropping `compare` would force every comparison through `Duration`. Happy to remove if you'd prefer a smaller surface.

4. **No low-level "ints only" escape hatch.** The issue sketched `monotonic.milliseconds() -> Int`. Deliberately omitted in favour of `Duration`, but it would be cheap to add later if a use case justifies it.

5. **`Instant` is `Eq`-able by structural equality.** Two instants captured at the same tick compare equal; that's fine, but if runtime-identity tagging is ever added, structural equality becomes wrong. Worth deciding now whether to commit to it.

6. **Naming.** `Instant` matches Rust/Java terminology. Alternatives considered: `Tick`, `Mark`, `MonotonicInstant`. `Instant` reads best in usage (`monotonic.now() -> Instant`).

Happy to trim surface (e.g. drop `compare`), add a low-level int API, beef up doc warnings about JS resolution / Erlang time-warp, or split this into a smaller first PR — let me know which direction you'd prefer.