### PR TITLE
Fix typo substracting -> subtracting

### DIFF
--- a/src/gleam/time/duration.gleam
+++ b/src/gleam/time/duration.gleam
@@ -152,7 +152,7 @@ pub fn compare(left: Duration, right: Duration) -> order.Order {
 
 /// Calculate the difference between two durations.
 ///
-/// This is effectively substracting the first duration from the second.
+/// This is effectively subtracting the first duration from the second.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
The typo prevents the difference function from coming up when searching for "subtract".